### PR TITLE
250903 ログイン権限設定、ホーム画面のヘッダーの情報、テスト作成

### DIFF
--- a/frontend/src/app/__tests__/page.test.tsx
+++ b/frontend/src/app/__tests__/page.test.tsx
@@ -1,15 +1,18 @@
-import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
-import Page from '../page'
+/**
+ * @jest-environment jsdom
+ */
+import * as nextNavigation from "next/navigation";
+import HomePage from "../page";
 
-describe('Home Page', () => {
-  it('renders the main content', () => {
-    render(<Page />)
+// Mock setup
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(),
+}));
 
-    const mainElement = screen.getByRole('main');
-    expect(mainElement).toBeInTheDocument();
-
-    const nextLogo = screen.getByAltText('Next.js logo');
-    expect(nextLogo).toBeInTheDocument();
-  })
-})
+// Tests
+describe("Home Page", () => {
+  it("redirects to /login", () => {
+    HomePage();
+    expect(nextNavigation.redirect).toHaveBeenCalledWith("/login");
+  });
+});

--- a/frontend/src/app/home/components/HeaderForm.tsx
+++ b/frontend/src/app/home/components/HeaderForm.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useUser } from "@/hooks/userContext";
+import { useRouter } from "next/navigation";
+import { UserRole, UserRoleLabel } from "@/constants/roles";
+
+interface MenuItem {
+  label: string;
+  roles: UserRole[];
+}
+
+const Header: React.FC = () => {
+  const { user, loading, logout } = useUser();
+  const router = useRouter();
+
+  const titles: MenuItem[] = [
+    { label: "🏠 間取り生成システム", roles: [UserRole.MEMBER] },
+    { label: "👥 ユーザー管理", roles: [UserRole.COMPANY_ADMIN] },
+    { label: "👥 会社管理 ", roles: [UserRole.SYSTEM_ADMIN] },
+  ];
+
+  const menuItems: MenuItem[] = [
+    { label: "間取り生成", roles: [UserRole.MEMBER] },
+    {
+      label: "対応履歴",
+      roles: [UserRole.MEMBER, UserRole.COMPANY_ADMIN, UserRole.SYSTEM_ADMIN],
+    },
+    { label: "⭐ お気に入り", roles: [UserRole.MEMBER] },
+    { label: "マイページ", roles: [UserRole.MEMBER] },
+    { label: "ユーザー管理", roles: [UserRole.COMPANY_ADMIN] },
+    {
+      label: "会社管理",
+      roles: [UserRole.SYSTEM_ADMIN],
+    },
+  ];
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/login");
+    }
+  }, [user, loading, router]);
+
+  if (loading) return <p>ロード中...</p>;
+  if (!user) return null;
+
+  const handleLogout = () => {
+    logout();
+  };
+
+  const currentRole = user.role as UserRole;
+
+  return (
+    <header className="flex items-center justify-between bg-[#3C4858] text-white px-6 py-4 rounded-lg text-lg">
+      <div className="flex items-center space-x-2">
+        {titles
+          .filter((item) => item.roles.includes(currentRole))
+          .map((item) => (
+            <h1 key={item.label} className="text-lg font-bold">
+              {item.label}
+            </h1>
+          ))}
+      </div>
+
+      <nav className="flex items-center space-x-4">
+        {menuItems
+          .filter((item) => item.roles.includes(currentRole))
+          .map((item) => (
+            <button
+              key={item.label}
+              className="bg-[#4A5568] hover:bg-[#5a6cdb] px-4 py-1 rounded"
+            >
+              {item.label}
+            </button>
+          ))}
+      </nav>
+
+      <div className="flex items-center space-x-4">
+        <p className="text-lg">
+          <span className="font-semibold">
+            {`${UserRoleLabel[currentRole]} : ${user.name}`}
+          </span>
+        </p>
+        <button
+          onClick={handleLogout}
+          className="bg-gray-200 text-gray-800 px-2 py-1 text-sm rounded hover:bg-gray-400"
+        >
+          ログアウト
+        </button>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import React from "react";
+import Header from "./components/HeaderForm";
+
+const Home: React.FC = () => {
+  return (
+    <div className="w-full max-w-[1400px] rounded-lg bg-gray-50 shadow-sm px-5 py-6 border-2 border-dashed border-gray-300">
+      <Header />
+    </div>
+  );
+};
+
+export default Home;

--- a/frontend/src/app/home/tests/HeaderForm.test.tsx
+++ b/frontend/src/app/home/tests/HeaderForm.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { UserRole } from "@/constants/roles";
+import { useUser } from "@/hooks/userContext";
+import Header from "../components/HeaderForm";
+import { useRouter } from "next/navigation";
+
+// Mock setup
+jest.mock("@/hooks/userContext", () => ({
+  useUser: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+const mockLogout = jest.fn();
+const mockPush = jest.fn();
+
+(useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+
+const setup = (role: UserRole, name: string) => {
+  (useUser as jest.Mock).mockReturnValue({
+    user: { role, name },
+    loading: false,
+    logout: mockLogout,
+  });
+
+  render(<Header />);
+};
+
+// Tests
+describe("Header Component", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("営業担当者(MEMBER)のUIが表示される", () => {
+    setup(UserRole.MEMBER, "テストユーザー");
+
+    // タイトル
+    expect(screen.getByText("🏠 間取り生成システム")).toBeInTheDocument();
+
+    // メニュー
+    expect(screen.getByText("間取り生成")).toBeInTheDocument();
+    expect(screen.getByText("対応履歴")).toBeInTheDocument();
+    expect(screen.getByText("⭐ お気に入り")).toBeInTheDocument();
+    expect(screen.getByText("マイページ")).toBeInTheDocument();
+
+    // 権限表示
+    expect(screen.getByText("営業 : テストユーザー")).toBeInTheDocument();
+  });
+
+  test("会社管理担当者(COMPANY_ADMIN)のUIが表示される", () => {
+    setup(UserRole.COMPANY_ADMIN, "テスト会社担当者");
+
+    // タイトル
+    expect(screen.getByText("👥 ユーザー管理")).toBeInTheDocument();
+
+    // メニュー
+    expect(screen.getByText("対応履歴")).toBeInTheDocument();
+    expect(screen.getByText("ユーザー管理")).toBeInTheDocument();
+
+    // 権限表示
+    expect(screen.getByText("管理者 : テスト会社担当者")).toBeInTheDocument();
+  });
+
+  test("システム管理者(SYSTEM_ADMIN)のUIが表示される", () => {
+    setup(UserRole.SYSTEM_ADMIN, "テストシステム担当者");
+
+    // タイトル
+    expect(screen.getByText("👥 会社管理")).toBeInTheDocument();
+
+    // メニュー
+    expect(screen.getByText("対応履歴")).toBeInTheDocument();
+    expect(screen.getByText("会社管理")).toBeInTheDocument();
+
+    // 権限表示
+    expect(
+      screen.getByText("管理者 : テストシステム担当者")
+    ).toBeInTheDocument();
+  });
+
+  test("ログアウトボタン呼び出し可能", () => {
+    setup(UserRole.MEMBER, "テストユーザー");
+
+    const logoutBtn = screen.getByRole("button", { name: /ログアウト/i });
+    logoutBtn.click();
+
+    expect(mockLogout).toHaveBeenCalled();
+  });
+
+  test("loading中はロード中メッセージ表示", () => {
+    (useUser as jest.Mock).mockReturnValue({
+      user: null,
+      loading: true,
+      logout: mockLogout,
+    });
+
+    render(<Header />);
+
+    expect(screen.getByText("ロード中...")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { UserProvider } from "@/hooks/userContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,9 +26,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased flex items-center justify-center min-h-screen bg-white p-4`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased flex justify-center min-h-screen bg-white p-4`}
       >
-        {children}
+        <UserProvider>{children}</UserProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/login/components/LoginForm.tsx
+++ b/frontend/src/app/login/components/LoginForm.tsx
@@ -1,15 +1,22 @@
 "use client";
 
+import { LoginResponse, useUser } from "@/hooks/userContext";
+import { loginUser } from "@/lib/api";
+import { useRouter } from "next/navigation";
 import React, { useState, FormEvent } from "react";
 
 // ログイン
 const LoginForm: React.FC = () => {
+  const router = useRouter();
+  const { setUser } = useUser();
+
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [emailError, setEmailError] = useState<string>("");
   const [passwordError, setPasswordError] = useState<string>("");
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
-  const [rememberMe, setRememberMe] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [loginError, setLoginError] = useState<string>("");
 
   // バリデーションチェック
   const validateEmail = (email: string): boolean => {
@@ -17,6 +24,7 @@ const LoginForm: React.FC = () => {
     return re.test(String(email).toLowerCase());
   };
 
+  // ログイン
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -39,6 +47,23 @@ const LoginForm: React.FC = () => {
     }
 
     if (!isValid) return;
+
+    setLoading(true);
+
+    try {
+      // ログインAPI
+      const data: LoginResponse = await loginUser(email, password);
+
+      setUser(data);
+
+      // ログイン成功したらHOME画面に遷移
+      router.push("/home");
+    } catch (err) {
+      console.error(err);
+      setLoginError("メールアドレスまたはパスワードが正しくありません");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -99,12 +124,10 @@ const LoginForm: React.FC = () => {
           <div className="mb-6 flex items-center text-sm text-gray-700">
             <input
               type="checkbox"
-              id="remember"
+              id="checkbox"
               className="h-4 w-4 text-[#667eea] border-gray-300 rounded focus:ring-blue-400"
-              checked={rememberMe}
-              onChange={(e) => setRememberMe(e.target.checked)}
             />
-            <label htmlFor="remember" className="ml-2 block">
+            <label htmlFor="checkbox" className="ml-2 block">
               ログイン状態を保持する
             </label>
           </div>
@@ -113,7 +136,7 @@ const LoginForm: React.FC = () => {
             type="submit"
             className="w-full bg-[#667eea] hover:bg-[#5a6cdb] text-white font-bold py-2 px-4 rounded-sm transition duration-300"
           >
-            ログイン
+            {loading ? "ログイン中..." : "ログイン"}
           </button>
         </form>
 
@@ -131,11 +154,11 @@ const LoginForm: React.FC = () => {
           </a>
         </div>
 
-        {/* エラー表示 */}
-        {(emailError || passwordError) && (
+        {/* ログインエラー表示 */}
+        {loginError && (
           <div className="mt-6 p-3 bg-[#FDF9F2] border-l-4 border-[#E5933C] rounded-sm">
             <p className="flex items-center text-[#B07020] text-[14px]">
-              ⚠️ エラー: メールアドレスまたはパスワードが正しくありません
+              ⚠️ エラー: {loginError}
             </p>
           </div>
         )}

--- a/frontend/src/app/login/components/LoginForm.tsx
+++ b/frontend/src/app/login/components/LoginForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { UserRole } from "@/constants/roles";
 import { LoginResponse, useUser } from "@/hooks/userContext";
+import { loginUser } from "@/lib/api";
 import { useRouter } from "next/navigation";
 import React, { useState, FormEvent, useEffect } from "react";
 
@@ -59,17 +59,9 @@ const LoginForm: React.FC = () => {
 
     try {
       // ログインAPI
-      // const data: LoginResponse = await loginUser(email, password);
+      const data: LoginResponse = await loginUser(email, password);
 
-      // setUser(data);
-
-      const dummyData: LoginResponse = {
-        id: 1,
-        name: "テストユーザー",
-        token: "123123123123",
-        role: UserRole.MEMBER,
-      };
-      setUser(dummyData);
+      setUser(data);
 
       // ログイン成功したらHOME画面に遷移
       router.push("/home");

--- a/frontend/src/app/login/components/LoginForm.tsx
+++ b/frontend/src/app/login/components/LoginForm.tsx
@@ -1,14 +1,14 @@
 "use client";
 
+import { UserRole } from "@/constants/roles";
 import { LoginResponse, useUser } from "@/hooks/userContext";
-import { loginUser } from "@/lib/api";
 import { useRouter } from "next/navigation";
-import React, { useState, FormEvent } from "react";
+import React, { useState, FormEvent, useEffect } from "react";
 
 // ログイン
 const LoginForm: React.FC = () => {
   const router = useRouter();
-  const { setUser } = useUser();
+  const { user, setUser } = useUser();
 
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
@@ -17,6 +17,13 @@ const LoginForm: React.FC = () => {
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [loginError, setLoginError] = useState<string>("");
+
+  // すでにログインしている場合は、ホーム画面に遷移
+  useEffect(() => {
+    if (user) {
+      router.push("/home");
+    }
+  }, [user, router]);
 
   // バリデーションチェック
   const validateEmail = (email: string): boolean => {
@@ -52,9 +59,17 @@ const LoginForm: React.FC = () => {
 
     try {
       // ログインAPI
-      const data: LoginResponse = await loginUser(email, password);
+      // const data: LoginResponse = await loginUser(email, password);
 
-      setUser(data);
+      // setUser(data);
+
+      const dummyData: LoginResponse = {
+        id: 1,
+        name: "テストユーザー",
+        token: "123123123123",
+        role: UserRole.MEMBER,
+      };
+      setUser(dummyData);
 
       // ログイン成功したらHOME画面に遷移
       router.push("/home");

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -3,7 +3,7 @@ import LoginForm from "@/app/login/components/LoginForm";
 // ログイン画面
 export default function LoginPage() {
   return (
-    <div>
+    <div className="flex items-center">
       <LoginForm />
     </div>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,4 +3,5 @@ import { redirect } from "next/navigation";
 // 初期画面
 export default function HomePage() {
   redirect("/login");
+  return <></>;
 }

--- a/frontend/src/constants/roles.ts
+++ b/frontend/src/constants/roles.ts
@@ -1,0 +1,11 @@
+export enum UserRole {
+  MEMBER = "MEMBER",
+  COMPANY_ADMIN = "COMPANY_ADMIN",
+  SYSTEM_ADMIN = "SYSTEM_ADMIN",
+}
+
+export const UserRoleLabel: Record<UserRole, string> = {
+  [UserRole.MEMBER]: "営業",
+  [UserRole.COMPANY_ADMIN]: "管理者",
+  [UserRole.SYSTEM_ADMIN]: "管理者",
+};

--- a/frontend/src/hooks/userContext.tsx
+++ b/frontend/src/hooks/userContext.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, {
+  createContext,
+  useState,
+  useContext,
+  ReactNode,
+  useEffect,
+} from "react";
+
+export interface LoginResponse {
+  id: number;
+  name: string;
+  token: string;
+  role: "MEMBER" | "COMPANY_ADMIN" | "SYSTEM_ADMIN";
+}
+
+interface UserContextProps {
+  user: LoginResponse | null;
+  loading: boolean;
+  setUser: (user: LoginResponse | null) => void;
+  logout: () => void;
+}
+
+const UserContext = createContext<UserContextProps>({
+  user: null,
+  loading: true,
+  setUser: () => {},
+  logout: () => {},
+});
+
+export const UserProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUserState] = useState<LoginResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // ページリフレッシュ時　sessionStorageから復元
+  useEffect(() => {
+    const storedUser = sessionStorage.getItem("user");
+    if (storedUser) {
+      setUserState(JSON.parse(storedUser));
+    }
+    setLoading(false);
+  }, []);
+
+  const setUser = (userData: LoginResponse | null) => {
+    setUserState(userData);
+    if (userData) {
+      sessionStorage.setItem("user", JSON.stringify(userData));
+    } else {
+      sessionStorage.removeItem("user");
+    }
+  };
+
+  const logout = () => setUser(null);
+
+  return (
+    <UserContext.Provider value={{ user, loading, setUser, logout }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUser = () => useContext(UserContext);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,11 +1,11 @@
 // APIリクエストを送信するための共通関数をここに定義します。
 // これにより、fetchの呼び出し元で毎回ヘッダーやエラーハンドリングを記述する必要がなくなります。
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 
 async function fetchApi(path: string, options: RequestInit = {}) {
   const headers = {
-    'Content-Type': 'application/json',
+    "Content-Type": "application/json",
     ...options.headers,
   };
 
@@ -23,7 +23,7 @@ async function fetchApi(path: string, options: RequestInit = {}) {
   if (!response.ok) {
     // エラーレスポンスをパースして、より詳細なエラー情報を提供する
     const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.message || 'API request failed');
+    throw new Error(errorData.message || "API request failed");
   }
 
   return response.json();
@@ -33,13 +33,25 @@ async function fetchApi(path: string, options: RequestInit = {}) {
 
 // 例: チームメンバーを取得するAPI
 export const getTeamMembers = () => {
-  return fetchApi('/api/admin/team/members', { method: 'GET' });
+  return fetchApi("/api/admin/team/members", { method: "GET" });
 };
 
 // 例: 新しいメンバーを作成するAPI
-export const createTeamMember = (data: { name: string; email: string; password: string }) => {
-  return fetchApi('/api/admin/team/members', {
-    method: 'POST',
+export const createTeamMember = (data: {
+  name: string;
+  email: string;
+  password: string;
+}) => {
+  return fetchApi("/api/admin/team/members", {
+    method: "POST",
     body: JSON.stringify(data),
+  });
+};
+
+// ログイン
+export const loginUser = (email: string, password: string) => {
+  return fetchApi("/api/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
   });
 };

--- a/frontend/tests/example.spec.ts
+++ b/frontend/tests/example.spec.ts
@@ -1,9 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('should navigate to the home page and display the title', async ({ page }) => {
-  // Start from the index page (the baseURL is set in the config)
-  await page.goto('/');
-
-  // The page should contain an image with the alt text "Next.js logo"
-  await expect(page.getByAltText('Next.js logo')).toBeVisible();
-});


### PR DESCRIPTION
概要
・認証成功後、ユーザーの権限（営業担当者、管理者）に応じて適切なトップページにリダイレクトさせる。

PBI番号
・F-001-FE-02

目的
・認証後、営業担当者、会社管理担当者、及び管理者それぞれの権限に応じて、表示されるヘッダー情報が自動的に切り替わること。

実装内容
・ログインAPIと連携し、ログインさせて次の画面に遷移させる
・ログインAPIのレスポンスにユーザー権限情報を含める
・フロントエンドで権限情報を元に表示されるヘッダー情報を制御するロジックを実装
・テストコード作成

動作確認チェックリスト
・ログイン後、次の画面の遷移ができるか
・権限情報を元に表示されるヘッダー情報が自動的に切り替わるか

レビューポイント
・ログイン後、次の画面の遷移先確認
・権限情報を元に表示されるヘッダー情報確認
・テストコード確認

その他