### PR TITLE
backend 間取図生成機能 公開API 1~5

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,6 +32,7 @@
                 "@types/morgan": "^1.9.10",
                 "@types/node": "^24.0.10",
                 "@types/supertest": "^6.0.3",
+                "@types/uuid": "^10.0.0",
                 "jest": "^30.0.5",
                 "prettier": "^3.6.2",
                 "prisma": "^6.11.1",
@@ -1759,6 +1760,13 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
             "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/uuid": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/yargs": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
                 "jsonwebtoken": "^9.0.2",
                 "morgan": "^1.10.1",
                 "ms": "^2.1.3",
+                "multer": "^2.0.2",
                 "ts-dotenv": "^0.9.1",
                 "winston": "^3.18.3",
                 "winston-daily-rotate-file": "^5.0.0"
@@ -30,9 +31,9 @@
                 "@types/jest": "^30.0.0",
                 "@types/jsonwebtoken": "^9.0.10",
                 "@types/morgan": "^1.9.10",
+                "@types/multer": "^2.0.0",
                 "@types/node": "^24.0.10",
                 "@types/supertest": "^6.0.3",
-                "@types/uuid": "^10.0.0",
                 "jest": "^30.0.5",
                 "prettier": "^3.6.2",
                 "prisma": "^6.11.1",
@@ -1664,6 +1665,16 @@
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "license": "MIT"
         },
+        "node_modules/@types/multer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.0.0.tgz",
+            "integrity": "sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/express": "*"
+            }
+        },
         "node_modules/@types/node": {
             "version": "24.0.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
@@ -1760,13 +1771,6 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
             "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
-            "license": "MIT"
-        },
-        "node_modules/@types/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/yargs": {
@@ -2157,6 +2161,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/append-field": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+            "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+            "license": "MIT"
+        },
         "node_modules/arg": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -2454,8 +2464,18 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/busboy": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "dependencies": {
+                "streamsearch": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.16.0"
+            }
         },
         "node_modules/bytes": {
             "version": "3.1.2",
@@ -2748,6 +2768,21 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "engines": [
+                "node >= 6.0"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
         },
         "node_modules/content-disposition": {
             "version": "1.0.0",
@@ -5148,7 +5183,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5234,6 +5268,79 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
+        },
+        "node_modules/multer": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+            "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+            "license": "MIT",
+            "dependencies": {
+                "append-field": "^1.0.0",
+                "busboy": "^1.6.0",
+                "concat-stream": "^2.0.0",
+                "mkdirp": "^0.5.6",
+                "object-assign": "^4.1.1",
+                "type-is": "^1.6.18",
+                "xtend": "^4.0.2"
+            },
+            "engines": {
+                "node": ">= 10.16.0"
+            }
+        },
+        "node_modules/multer/node_modules/media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/multer/node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/multer/node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/multer/node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/multer/node_modules/type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "license": "MIT",
+            "dependencies": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/napi-postinstall": {
             "version": "0.3.3",
@@ -6135,6 +6242,14 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/streamsearch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6614,6 +6729,12 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+            "license": "MIT"
+        },
         "node_modules/typescript": {
             "version": "5.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -6943,7 +7064,6 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4"

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "test": "jest",
         "setup": "npm install prisma --save-dev && npx prisma init --datasource-provider mysql",
-        "dev": "npm run prettier && ts-node-dev --respawn src/app.ts",
+        "dev": "ts-node-dev --respawn src/app.ts",
         "docker:start": "sleep 5 && npx prisma migrate deploy && npx prisma db seed && npm run dev",
         "prettier": "prettier --write ."
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/morgan": "^1.9.10",
+        "@types/multer": "^2.0.0",
         "@types/node": "^24.0.10",
         "@types/supertest": "^6.0.3",
         "jest": "^30.0.5",
@@ -43,6 +44,7 @@
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.1",
         "ms": "^2.1.3",
+        "multer": "^2.0.2",
         "ts-dotenv": "^0.9.1",
         "winston": "^3.18.3",
         "winston-daily-rotate-file": "^5.0.0"

--- a/backend/src/ApplicationErrors.ts
+++ b/backend/src/ApplicationErrors.ts
@@ -11,3 +11,5 @@ export class BaseError extends Error {
 }
 export class LoginError extends BaseError {}
 export class UserModificationError extends BaseError {}
+export class FloorplanGenerationError extends BaseError {}
+export class FloorplanGenerationNotCompletedError extends BaseError {}

--- a/backend/src/ApplicationErrors.ts
+++ b/backend/src/ApplicationErrors.ts
@@ -13,3 +13,4 @@ export class LoginError extends BaseError {}
 export class UserModificationError extends BaseError {}
 export class FloorplanGenerationError extends BaseError {}
 export class FloorplanGenerationNotCompletedError extends BaseError {}
+export class FloorplanImageError extends BaseError {}

--- a/backend/src/DBMgr.ts
+++ b/backend/src/DBMgr.ts
@@ -13,6 +13,13 @@ import { Prisma, Role } from '@prisma/client';
 import { createLogger } from './logger';
 import { CompanyInfo, CreateCompanyDataInput, UpdateCompanyDataInput } from './Types/CompanyParam';
 import { HistoryChildInfo, HistoryInfo } from './Types/HistoryParam';
+import {
+    CreateFloorPlanDataInput,
+    CreateHistoryChildDataInput,
+    CreateHistoryParentDataInput,
+    FloorPlanGenerationJobInfor,
+    RequestPayload
+} from './Types/FloorplanParam';
 
 export default class DBMgr {
     private logger;
@@ -347,7 +354,7 @@ export default class DBMgr {
         historyParentId: number,
         userId: number,
         authPayload: AuthTokenPayload
-    ): Promise<HistoryChildInfo[] | null> {
+    ): Promise<HistoryChildInfo[]> {
         this.logger.debug(
             `getHistoryChildren(${historyParentId}, ${userId}, ${JSON.stringify(authPayload)}})`
         );
@@ -432,6 +439,147 @@ export default class DBMgr {
                 where: { companyId },
                 data: { deleted: true }
             });
+        });
+    }
+
+    /**
+     * Creates a new floor plan generation job in the database.
+     *
+     * @param createData - The input data required to create the floor plan generation job
+     */
+    public async createFloorPlanGenerationJob(createData: CreateFloorPlanDataInput): Promise<void> {
+        this.logger.debug(`createFloorPlanGenerationJob(${JSON.stringify(createData)})`);
+
+        await prisma.floorPlanGenerationJob.create({
+            data: { ...createData }
+        });
+    }
+
+    /**
+     * Gets a floor plan generation job by its ID.
+     *
+     * @param jobId - The unique identifier (UUID) of the floor plan generation job
+     * @returns Floorplan generation information
+     */
+    public async getFloorPlanGenerationJob(
+        jobId: string
+    ): Promise<FloorPlanGenerationJobInfor | null> {
+        this.logger.debug(`getFloorPlanGenerationJob(${jobId})`);
+
+        const result = await prisma.floorPlanGenerationJob.findUnique({
+            select: {
+                jobId: true,
+                status: true,
+                progress: true,
+                estimatedTime: true,
+                requestPayload: true,
+                resultPayload: true,
+                historyParentId: true,
+                requestUserId: true
+            },
+            where: {
+                jobId
+            }
+        });
+
+        if (!result) {
+            return null;
+        }
+        return {
+            ...result,
+            requestPayload: result.requestPayload as RequestPayload
+        };
+    }
+
+    /**
+     * Creates a new history parent record in the database.
+     *
+     * @param createData - The data required to create the history parent record
+     * @param tx - Optional Prisma transaction client to execute the creation within a transaction
+     * @returns The ID of the newly created history parent record
+     */
+    public async createHistoryParent(
+        createData: CreateHistoryParentDataInput,
+        tx?: Prisma.TransactionClient
+    ): Promise<number> {
+        this.logger.debug(`createHistoryParent(${JSON.stringify(createData)})`);
+
+        const client = tx || prisma;
+        const newHistoryParent = await client.historyParent.create({
+            data: { ...createData }
+        });
+
+        return newHistoryParent.id;
+    }
+
+    /**
+     * Creates multiple history child records in the database.
+     *
+     * @param createDataList - An array of history child data to be created
+     * @param tx - Optional Prisma transaction client to execute the creation within a transaction
+     */
+    public async createHistoryChildren(
+        createDataList: CreateHistoryChildDataInput[],
+        tx?: Prisma.TransactionClient
+    ): Promise<void> {
+        this.logger.debug(`createHistoryChildren(${JSON.stringify(createDataList)})`);
+
+        const client = tx || prisma;
+        await client.historyChild.createMany({
+            data: createDataList
+        });
+    }
+
+    /**
+     * Updates the historyParentId for a specific floor plan generation job.
+     *
+     * @param jobId - The unique identifier of the floor plan generation job to update
+     * @param historyParentId - The ID of the history parent record to associate with the job
+     * @param tx - Optional Prisma transaction client to execute the update within a transaction
+     */
+    public async updateHistoryParentIdForFloorPlanJob(
+        jobId: string,
+        historyParentId: number,
+        tx?: Prisma.TransactionClient
+    ): Promise<void> {
+        this.logger.debug(`updateHistoryParentIdForFloorPlanJob(${jobId}, ${historyParentId})`);
+
+        const client = tx || prisma;
+        await client.floorPlanGenerationJob.update({
+            where: { jobId },
+            data: { historyParentId }
+        });
+    }
+
+    /**
+     * Updates the favorite status of a history child record.
+     *
+     * @param historyChildId - The ID of the history child record to update
+     * @param isPatternFavorite - Whether the history child should be marked as favorite
+     */
+    public async toggleHistoryChildFavorite(
+        historyChildId: number,
+        isPatternFavorite: boolean
+    ): Promise<void> {
+        this.logger.debug(`toggleHistoryChildFavorite(${historyChildId}, ${isPatternFavorite})`);
+
+        await prisma.historyChild.update({
+            where: { id: historyChildId },
+            data: { isPatternFavorite }
+        });
+    }
+
+    /**
+     * Removes a history child record by marking it as deleted.
+     *
+     * @param historyChildId - The ID of the history child record to remove
+     */
+    public async removeHistoryChild(historyChildId: number): Promise<void> {
+        this.logger.debug(`removeHistoryChild(${historyChildId})`);
+
+        await prisma.historyChild.update({
+            where: { id: historyChildId },
+            data: { deleted: true }
         });
     }
 }

--- a/backend/src/DBMgr.ts
+++ b/backend/src/DBMgr.ts
@@ -18,6 +18,9 @@ import {
     CreateHistoryChildDataInput,
     CreateHistoryParentDataInput,
     FloorPlanGenerationJobInfor,
+    HistoryChildFloorplanData,
+    LayoutConditions,
+    RegenerateHistoryParent,
     RequestPayload
 } from './Types/FloorplanParam';
 
@@ -446,11 +449,16 @@ export default class DBMgr {
      * Creates a new floor plan generation job in the database.
      *
      * @param createData - The input data required to create the floor plan generation job
+     * @param tx - Optional Prisma transaction client
      */
-    public async createFloorPlanGenerationJob(createData: CreateFloorPlanDataInput): Promise<void> {
+    public async createFloorPlanGenerationJob(
+        createData: CreateFloorPlanDataInput,
+        tx?: Prisma.TransactionClient
+    ): Promise<void> {
         this.logger.debug(`createFloorPlanGenerationJob(${JSON.stringify(createData)})`);
 
-        await prisma.floorPlanGenerationJob.create({
+        const client = tx || prisma;
+        await client.floorPlanGenerationJob.create({
             data: { ...createData }
         });
     }
@@ -495,7 +503,7 @@ export default class DBMgr {
      * Creates a new history parent record in the database.
      *
      * @param createData - The data required to create the history parent record
-     * @param tx - Optional Prisma transaction client to execute the creation within a transaction
+     * @param tx - Optional Prisma transaction client
      * @returns The ID of the newly created history parent record
      */
     public async createHistoryParent(
@@ -516,7 +524,7 @@ export default class DBMgr {
      * Creates multiple history child records in the database.
      *
      * @param createDataList - An array of history child data to be created
-     * @param tx - Optional Prisma transaction client to execute the creation within a transaction
+     * @param tx - Optional Prisma transaction client
      */
     public async createHistoryChildren(
         createDataList: CreateHistoryChildDataInput[],
@@ -535,7 +543,7 @@ export default class DBMgr {
      *
      * @param jobId - The unique identifier of the floor plan generation job to update
      * @param historyParentId - The ID of the history parent record to associate with the job
-     * @param tx - Optional Prisma transaction client to execute the update within a transaction
+     * @param tx - Optional Prisma transaction client
      */
     public async updateHistoryParentIdForFloorPlanJob(
         jobId: string,
@@ -580,6 +588,60 @@ export default class DBMgr {
         await prisma.historyChild.update({
             where: { id: historyChildId },
             data: { deleted: true }
+        });
+    }
+
+    /**
+     * Get historyParent information.
+     *
+     * @param historyParentId - The ID of the history child record to remove
+     * @returns HistoryParent information
+     */
+    public async getRegenerateHistoryParent(
+        historyParentId: number
+    ): Promise<RegenerateHistoryParent | null> {
+        this.logger.debug(`getRegenerateHistoryParent(${historyParentId})`);
+
+        const historyParent = await prisma.historyParent.findUnique({
+            select: {
+                title: true,
+                customerName: true,
+                conditions: true
+            },
+            where: {
+                id: historyParentId,
+                deleted: false
+            }
+        });
+
+        if (!historyParent) {
+            return null;
+        }
+
+        return {
+            ...historyParent,
+            conditions: historyParent.conditions as LayoutConditions
+        };
+    }
+
+    /**
+     * Updates a floorplan.
+     *
+     * @param historyChildId - The ID of the history child record to remove
+     * @param updateFloorplanData - Update floorplan data for historyChild
+     */
+    public async updateHistoryChildFloorplanAndDownload(
+        historyChildId: number,
+        updateFloorplanData: HistoryChildFloorplanData
+    ): Promise<void> {
+        this.logger.debug(`updateHistoryChildFloorplanAndDownload(${historyChildId})`);
+
+        await prisma.historyChild.update({
+            where: { id: historyChildId },
+            data: {
+                floorplanData: updateFloorplanData,
+                isDownloaded: true
+            }
         });
     }
 }

--- a/backend/src/DSMgr.ts
+++ b/backend/src/DSMgr.ts
@@ -5,7 +5,12 @@ import DBMgr from './DBMgr';
 import { AuthTokenPayload, LoginResult, UserByEmail } from './Types/LoginParam';
 import { CreateUserDataInput, UpdateUserDataInput, UserInfoOutput } from './Types/UserParam';
 import bcrypt from 'bcrypt';
-import { UserModificationError, LoginError } from './ApplicationErrors';
+import {
+    UserModificationError,
+    LoginError,
+    FloorplanGenerationError,
+    FloorplanGenerationNotCompletedError
+} from './ApplicationErrors';
 import { AppConstant } from './SpecificCommons';
 import { Prisma, Role } from '@prisma/client';
 import { createAuthToken } from './commonUtils';
@@ -15,7 +20,9 @@ import {
     CreateCompanyDataInput,
     UpdateCompanyDataInput
 } from './Types/CompanyParam';
-import { HistoryChildInfo, HistoryChildInfoOutput, HistoryInfoOutput } from './Types/HistoryParam';
+import { HistoryChildInfoOutput, HistoryInfoOutput } from './Types/HistoryParam';
+import { FloorplanGenerationStatus, RequestPayload } from './Types/FloorplanParam';
+import prisma from '../prisma/client';
 
 export default class DSMgr {
     private dbMgr: DBMgr;
@@ -51,7 +58,7 @@ export default class DSMgr {
                 throw new LoginError('The password is incorrect.');
             }
 
-            const jwtPayload = { role: user.role, companyId: user.companyId };
+            const jwtPayload = { userId: user.id, role: user.role, companyId: user.companyId };
             const token: string = createAuthToken(jwtPayload);
 
             return {
@@ -330,6 +337,194 @@ export default class DSMgr {
             };
         } catch (err) {
             this.logger.error('getHistoryChildren() Unexpected error', err);
+            throw err;
+        }
+    }
+
+    /**
+     * Floorplan generation request.
+     *
+     * @param requestPayload - The request data sent to the Python service for processing
+     * @param userId - The ID of the user requesting the data
+     * @returns jobId
+     */
+    public async createFloorplanGenerationJob(
+        requestPayload: RequestPayload,
+        userId: number
+    ): Promise<{ jobId: string }> {
+        this.logger.debug(`createFloorplanGenerationJob(${JSON.stringify(requestPayload)})`);
+
+        try {
+            const jobId = crypto.randomUUID();
+            // TODO: Send the requestPayload to Python for processing
+
+            // Save floor plan generation job to the database
+            const createFloorPlanData = {
+                jobId,
+                status: AppConstant.FLOORPLAN_GENERATION.STATUS.PROCESSING,
+                progress: 0,
+                estimatedTime: '60s',
+                requestPayload: requestPayload,
+                requestUserId: userId
+            };
+            await this.dbMgr.createFloorPlanGenerationJob(createFloorPlanData);
+
+            return { jobId };
+        } catch (err) {
+            this.logger.error('createFloorplanGenerationJob() Unexpected error', err);
+            throw err;
+        }
+    }
+
+    /**
+     * Get floorplan generation status.
+     *
+     * @param jobId - The unique identifier (UUID) of the floor plan generation job
+     * @returns Floorplan generation status information
+     */
+    public async getFloorplanGenerationStatus(jobId: string): Promise<FloorplanGenerationStatus> {
+        this.logger.debug(`getFloorplanGenerationStatus(${jobId})`);
+
+        try {
+            const floorplanGeneration = await this.dbMgr.getFloorPlanGenerationJob(jobId);
+            if (!floorplanGeneration) {
+                throw new FloorplanGenerationError('FloorplanGeneration was not found.');
+            }
+
+            if (AppConstant.FLOORPLAN_GENERATION.STATUS.COMPLETED === floorplanGeneration.status) {
+                const createHistoryParentData = {
+                    title: floorplanGeneration.requestPayload.title,
+                    conditions: floorplanGeneration.requestPayload.layout_conditions,
+                    customerName: floorplanGeneration.requestPayload.clientName,
+                    createdById: floorplanGeneration.requestUserId,
+                    updatedId: floorplanGeneration.requestUserId
+                };
+
+                const layouts = [
+                    floorplanGeneration.resultPayload.layout_1,
+                    floorplanGeneration.resultPayload.layout_2,
+                    floorplanGeneration.resultPayload.layout_3
+                ];
+
+                await prisma.$transaction(async (tx) => {
+                    const newHistoryParentId: number = await this.dbMgr.createHistoryParent(
+                        createHistoryParentData,
+                        tx
+                    );
+
+                    await this.dbMgr.updateHistoryParentIdForFloorPlanJob(
+                        jobId,
+                        newHistoryParentId,
+                        tx
+                    );
+
+                    const historyChildrenData = layouts.map((layout) => {
+                        const { type, ...floorplanData } = layout;
+
+                        return {
+                            historyParentId: newHistoryParentId,
+                            patternName: type,
+                            floorplanData,
+                            tag: layout.tag.join(','),
+                            createdById: floorplanGeneration.requestUserId
+                        };
+                    });
+                    await this.dbMgr.createHistoryChildren(historyChildrenData, tx);
+                });
+            }
+
+            return {
+                jobId,
+                status: floorplanGeneration.status,
+                progress: floorplanGeneration.progress,
+                estimatedTime: floorplanGeneration.estimatedTime
+            };
+        } catch (err) {
+            if (err instanceof FloorplanGenerationError) {
+                this.logger.warn(`Failed to get floorplanGeneration status: ${err.message}`);
+            } else {
+                this.logger.error('getFloorplanGenerationStatus() Unexpected error', err);
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * Get floorplan generation results.
+     *
+     * @param jobId - The unique identifier (UUID) of the floor plan generation job
+     * @param authPayload - The authorization token payload of the requester
+     * @returns Floorplan generation results
+     */
+    public async getFloorplanGenerationResults(
+        jobId: string,
+        authPayload: AuthTokenPayload
+    ): Promise<HistoryChildInfoOutput> {
+        this.logger.debug(`getFloorplanGenerationResults(${jobId})`);
+
+        try {
+            const floorplanGeneration = await this.dbMgr.getFloorPlanGenerationJob(jobId);
+            if (!floorplanGeneration || !floorplanGeneration.historyParentId) {
+                throw new FloorplanGenerationError('FloorplanGeneration was not found.');
+            }
+            if (AppConstant.FLOORPLAN_GENERATION.STATUS.COMPLETED !== floorplanGeneration.status) {
+                throw new FloorplanGenerationNotCompletedError(
+                    'FloorplanGeneration is not completed.'
+                );
+            }
+
+            const floorplanGenerationResults = await this.dbMgr.getHistoryChildren(
+                floorplanGeneration.historyParentId,
+                floorplanGeneration.requestUserId,
+                authPayload
+            );
+            return {
+                historyChildren: floorplanGenerationResults
+            };
+        } catch (err) {
+            if (err instanceof FloorplanGenerationError) {
+                this.logger.warn(`Failed to get floorplanGeneration results: ${err.message}`);
+            } else if (err instanceof FloorplanGenerationNotCompletedError) {
+                this.logger.warn(`Failed to get floorplanGeneration results: ${err.message}`);
+            } else {
+                this.logger.error('getFloorplanGenerationResults() Unexpected error', err);
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * Toggles the favorite status of a floorplan.
+     *
+     * @param historyChildId - The ID of the child history record
+     * @param isPatternFavorite - Whether the pattern is a favorite.
+     */
+    public async toggleHistoryChildFavorite(
+        historyChildId: number,
+        isPatternFavorite: boolean
+    ): Promise<void> {
+        this.logger.debug(`toggleHistoryChildFavorite(${historyChildId}, ${isPatternFavorite})`);
+
+        try {
+            await this.dbMgr.toggleHistoryChildFavorite(historyChildId, isPatternFavorite);
+        } catch (err) {
+            this.logger.error('toggleHistoryChildFavorite() Unexpected error', err);
+            throw err;
+        }
+    }
+
+    /**
+     * Deletes a floorplan.
+     *
+     * @param historyChildId - The ID of the child history record
+     */
+    public async removeHistoryChild(historyChildId: number): Promise<void> {
+        this.logger.debug(`removeHistoryChild(${historyChildId})`);
+
+        try {
+            await this.dbMgr.removeHistoryChild(historyChildId);
+        } catch (err) {
+            this.logger.error('removeHistoryChild() Unexpected error', err);
             throw err;
         }
     }

--- a/backend/src/DSMgr.ts
+++ b/backend/src/DSMgr.ts
@@ -9,7 +9,8 @@ import {
     UserModificationError,
     LoginError,
     FloorplanGenerationError,
-    FloorplanGenerationNotCompletedError
+    FloorplanGenerationNotCompletedError,
+    FloorplanImageError
 } from './ApplicationErrors';
 import { AppConstant } from './SpecificCommons';
 import { Prisma, Role } from '@prisma/client';
@@ -21,8 +22,16 @@ import {
     UpdateCompanyDataInput
 } from './Types/CompanyParam';
 import { HistoryChildInfoOutput, HistoryInfoOutput } from './Types/HistoryParam';
-import { FloorplanGenerationStatus, RequestPayload } from './Types/FloorplanParam';
+import {
+    FloorplanGenerationStatus,
+    FloorplanImage,
+    HistoryChildFloorplanData,
+    RequestPayload
+} from './Types/FloorplanParam';
+import crypto from 'crypto';
 import prisma from '../prisma/client';
+import fs from 'fs/promises';
+import path from 'path';
 
 export default class DSMgr {
     private dbMgr: DBMgr;
@@ -346,13 +355,17 @@ export default class DSMgr {
      *
      * @param requestPayload - The request data sent to the Python service for processing
      * @param userId - The ID of the user requesting the data
+     * @param tx - Optional Prisma transaction client
      * @returns jobId
      */
     public async createFloorplanGenerationJob(
         requestPayload: RequestPayload,
-        userId: number
+        userId: number,
+        tx?: Prisma.TransactionClient
     ): Promise<{ jobId: string }> {
-        this.logger.debug(`createFloorplanGenerationJob(${JSON.stringify(requestPayload)})`);
+        this.logger.debug(
+            `createFloorplanGenerationJob(${JSON.stringify(requestPayload)}, ${userId})`
+        );
 
         try {
             const jobId = crypto.randomUUID();
@@ -361,13 +374,13 @@ export default class DSMgr {
             // Save floor plan generation job to the database
             const createFloorPlanData = {
                 jobId,
-                status: AppConstant.FLOORPLAN_GENERATION.STATUS.PROCESSING,
+                status: AppConstant.FLOORPLAN.GENERATION.STATUS.PROCESSING,
                 progress: 0,
                 estimatedTime: '60s',
                 requestPayload: requestPayload,
                 requestUserId: userId
             };
-            await this.dbMgr.createFloorPlanGenerationJob(createFloorPlanData);
+            await this.dbMgr.createFloorPlanGenerationJob(createFloorPlanData, tx);
 
             return { jobId };
         } catch (err) {
@@ -391,15 +404,8 @@ export default class DSMgr {
                 throw new FloorplanGenerationError('FloorplanGeneration was not found.');
             }
 
-            if (AppConstant.FLOORPLAN_GENERATION.STATUS.COMPLETED === floorplanGeneration.status) {
-                const createHistoryParentData = {
-                    title: floorplanGeneration.requestPayload.title,
-                    conditions: floorplanGeneration.requestPayload.layout_conditions,
-                    customerName: floorplanGeneration.requestPayload.clientName,
-                    createdById: floorplanGeneration.requestUserId,
-                    updatedId: floorplanGeneration.requestUserId
-                };
-
+            if (AppConstant.FLOORPLAN.GENERATION.STATUS.COMPLETED === floorplanGeneration.status) {
+                let historyParentId: number;
                 const layouts = [
                     floorplanGeneration.resultPayload.layout_1,
                     floorplanGeneration.resultPayload.layout_2,
@@ -407,22 +413,34 @@ export default class DSMgr {
                 ];
 
                 await prisma.$transaction(async (tx) => {
-                    const newHistoryParentId: number = await this.dbMgr.createHistoryParent(
-                        createHistoryParentData,
-                        tx
-                    );
+                    if (floorplanGeneration.historyParentId) {
+                        // Regenerate
+                        historyParentId = floorplanGeneration.historyParentId;
+                    } else {
+                        // New generate
+                        const createHistoryParentData = {
+                            title: floorplanGeneration.requestPayload.title,
+                            conditions: floorplanGeneration.requestPayload.layout_conditions,
+                            customerName: floorplanGeneration.requestPayload.clientName,
+                            createdById: floorplanGeneration.requestUserId,
+                            updatedId: floorplanGeneration.requestUserId
+                        };
+                        historyParentId = await this.dbMgr.createHistoryParent(
+                            createHistoryParentData,
+                            tx
+                        );
 
-                    await this.dbMgr.updateHistoryParentIdForFloorPlanJob(
-                        jobId,
-                        newHistoryParentId,
-                        tx
-                    );
-
+                        await this.dbMgr.updateHistoryParentIdForFloorPlanJob(
+                            jobId,
+                            historyParentId,
+                            tx
+                        );
+                    }
                     const historyChildrenData = layouts.map((layout) => {
                         const { type, ...floorplanData } = layout;
 
                         return {
-                            historyParentId: newHistoryParentId,
+                            historyParentId,
                             patternName: type,
                             floorplanData,
                             tag: layout.tag.join(','),
@@ -467,7 +485,7 @@ export default class DSMgr {
             if (!floorplanGeneration || !floorplanGeneration.historyParentId) {
                 throw new FloorplanGenerationError('FloorplanGeneration was not found.');
             }
-            if (AppConstant.FLOORPLAN_GENERATION.STATUS.COMPLETED !== floorplanGeneration.status) {
+            if (AppConstant.FLOORPLAN.GENERATION.STATUS.COMPLETED !== floorplanGeneration.status) {
                 throw new FloorplanGenerationNotCompletedError(
                     'FloorplanGeneration is not completed.'
                 );
@@ -525,6 +543,203 @@ export default class DSMgr {
             await this.dbMgr.removeHistoryChild(historyChildId);
         } catch (err) {
             this.logger.error('removeHistoryChild() Unexpected error', err);
+            throw err;
+        }
+    }
+
+    /**
+     * Regenerate floorplan.
+     *
+     * @param historyParentId - The ID of the parent history record
+     * @param userId - The ID of the user requesting the data
+     * @returns jobId
+     */
+    public async regenerateFloorplan(
+        historyParentId: number,
+        userId: number
+    ): Promise<{ jobId: string }> {
+        this.logger.debug(`regenerateFloorplan(${historyParentId}, ${userId})`);
+
+        try {
+            const historyParent = await this.dbMgr.getRegenerateHistoryParent(historyParentId);
+            if (!historyParent) {
+                throw new FloorplanGenerationError('HistoryParent was not found.');
+            }
+            const requestPayload: RequestPayload = {
+                title: historyParent.title ?? AppConstant.DEFAULT_NULL_STRING,
+                clientName: historyParent.customerName ?? AppConstant.DEFAULT_NULL_STRING,
+                layout_conditions: historyParent.conditions
+            };
+
+            return await prisma.$transaction(async (tx) => {
+                const { jobId } = await this.createFloorplanGenerationJob(
+                    requestPayload,
+                    userId,
+                    tx
+                );
+                await this.dbMgr.updateHistoryParentIdForFloorPlanJob(jobId, historyParentId, tx);
+                return { jobId };
+            });
+        } catch (err) {
+            if (err instanceof FloorplanGenerationError) {
+                this.logger.warn(`Failed to get floorplan regeneration: ${err.message}`);
+            } else {
+                this.logger.error('regenerateFloorplan() Unexpected error', err);
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * Updates a floorplan.
+     *
+     * @param historyChildId - The ID of the child history record
+     * @param updateFloorplanData - Update floorplan data for historyChild
+     */
+    public async updateFloorplan(
+        historyChildId: number,
+        updateFloorplanData: HistoryChildFloorplanData
+    ): Promise<void> {
+        this.logger.debug(
+            `updateFloorplan(${historyChildId}, ${JSON.stringify(updateFloorplanData)})`
+        );
+
+        try {
+            await this.dbMgr.updateHistoryChildFloorplanAndDownload(
+                historyChildId,
+                updateFloorplanData
+            );
+        } catch (err) {
+            this.logger.error('updateFloorplan() Unexpected error', err);
+            throw err;
+        }
+    }
+
+    /**
+     * Gets a list of equipment images.
+     *
+     * @returns List of equipment images with name and URL
+     */
+    public async getFloorplanImages(): Promise<FloorplanImage> {
+        this.logger.debug('getFloorplanImages()');
+
+        try {
+            const publicDir = path.join(__dirname, '..', 'public');
+
+            try {
+                await fs.access(publicDir);
+            } catch {
+                return {
+                    images: []
+                };
+            }
+
+            const files = await fs.readdir(publicDir);
+
+            const imageExtensions = ['.png', '.jpg', '.jpeg'];
+            const imageFiles = files.filter((file) =>
+                imageExtensions.includes(path.extname(file).toLowerCase())
+            );
+
+            const images = imageFiles.map((file) => ({
+                name: file,
+                url: `/backend/public/${file}`
+            }));
+
+            return { images };
+        } catch (err) {
+            this.logger.error('getFloorplanImages() Unexpected error', err);
+            throw err;
+        }
+    }
+
+    /**
+     * Uploads an equipment image.
+     *
+     * @param file - The uploaded file from multer
+     */
+    public async uploadFloorplanImage(file: Express.Multer.File): Promise<void> {
+        this.logger.debug(`uploadFloorplanImage(${file.originalname})`);
+
+        try {
+            const publicDir = path.join(__dirname, '..', 'public');
+
+            try {
+                await fs.access(publicDir);
+            } catch {
+                await fs.mkdir(publicDir, { recursive: true });
+            }
+
+            const allowedExtensions = ['.png', '.jpg', '.jpeg'];
+            const fileExt = path.extname(file.originalname).toLowerCase();
+
+            if (!allowedExtensions.includes(fileExt)) {
+                throw new FloorplanImageError('Invalid file format. Only image files are allowed.');
+            }
+
+            const maxFileSize = AppConstant.FLOORPLAN.IMAGE.MAX_FILE_SIZE; // 5MB
+            if (file.size > maxFileSize) {
+                throw new FloorplanImageError('File size exceeds 5MB limit.');
+            }
+
+            const targetPath = path.join(publicDir, file.originalname);
+            try {
+                await fs.access(targetPath);
+                throw new FloorplanImageError('File with the same name already exists.');
+            } catch (err) {
+                if (err instanceof FloorplanImageError) {
+                    throw err;
+                }
+            }
+
+            await fs.writeFile(targetPath, file.buffer);
+            this.logger.info(`Image uploaded successfully: ${file.originalname}`);
+        } catch (err) {
+            if (err instanceof FloorplanImageError) {
+                this.logger.warn(`Upload image failed: ${err.message}`);
+            } else {
+                this.logger.error('uploadFloorplanImage() Unexpected error', err);
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * Deletes an equipment image.
+     *
+     * @param name - The name of the image file to delete
+     */
+    public async deleteFloorplanImage(name: string): Promise<void> {
+        this.logger.debug(`deleteFloorplanImage('${name}')`);
+
+        try {
+            const publicDir = path.join(__dirname, '..', 'public');
+            const targetPath = path.join(publicDir, name);
+
+            const normalizedPath = path.normalize(targetPath);
+            if (!normalizedPath.startsWith(publicDir)) {
+                throw new FloorplanImageError('Invalid file path.');
+            }
+
+            try {
+                await fs.access(targetPath);
+            } catch {
+                throw new FloorplanImageError('File not found.');
+            }
+
+            const stats = await fs.stat(targetPath);
+            if (!stats.isFile()) {
+                throw new FloorplanImageError('Target is not a file.');
+            }
+
+            await fs.unlink(targetPath);
+            this.logger.info(`Image deleted successfully: ${name}`);
+        } catch (err) {
+            if (err instanceof FloorplanImageError) {
+                this.logger.warn(`Delete image failed: ${err.message}`);
+            } else {
+                this.logger.error('deleteFloorplanImage() Unexpected error', err);
+            }
             throw err;
         }
     }

--- a/backend/src/SpecificCommons.ts
+++ b/backend/src/SpecificCommons.ts
@@ -7,10 +7,16 @@ export const AppConstant = {
     BCRYPT: {
         SALT_ROUNDS: 10
     },
-    FLOORPLAN_GENERATION: {
-        STATUS: {
-            PROCESSING: 'processing',
-            COMPLETED: 'completed'
+    FLOORPLAN: {
+        GENERATION: {
+            STATUS: {
+                PROCESSING: 'processing',
+                COMPLETED: 'completed'
+            }
+        },
+        IMAGE: {
+            MAX_FILE_SIZE: 5 * 1024 * 1024
         }
-    }
+    },
+    DEFAULT_NULL_STRING: 'Not entered'
 };

--- a/backend/src/SpecificCommons.ts
+++ b/backend/src/SpecificCommons.ts
@@ -6,5 +6,11 @@
 export const AppConstant = {
     BCRYPT: {
         SALT_ROUNDS: 10
+    },
+    FLOORPLAN_GENERATION: {
+        STATUS: {
+            PROCESSING: 'processing',
+            COMPLETED: 'completed'
+        }
     }
 };

--- a/backend/src/Types/FloorplanParam.ts
+++ b/backend/src/Types/FloorplanParam.ts
@@ -1,0 +1,79 @@
+import { Prisma } from '@prisma/client';
+
+export type RequestPayload = {
+    title: string;
+    clientName: string;
+    layout_conditions: {
+        family_composition: {
+            value: string;
+            unit: string;
+        };
+        number_of_floors: {
+            value: string;
+        };
+        frontage: {
+            value: string;
+            unit: string;
+        };
+        depth: {
+            value: string;
+            unit: string;
+        };
+        desired_LDK_area: {
+            value: string;
+            unit: string;
+        };
+        number_of_rooms: {
+            value: string;
+            unit: string;
+        };
+        number_of_toilets: {
+            value: string;
+            unit: string;
+        };
+        commitment_flow_lines: {
+            value: string;
+            unit: string;
+        };
+    };
+};
+
+export type CreateFloorPlanDataInput = {
+    jobId: string;
+    status: string;
+    progress: number;
+    estimatedTime: string;
+    requestPayload: RequestPayload;
+    requestUserId: number;
+};
+
+export type CreateHistoryParentDataInput = {
+    title: string;
+    conditions: Prisma.InputJsonValue;
+    customerName: string;
+    createdById: number;
+    updatedId: number;
+};
+
+export type CreateHistoryChildDataInput = {
+    historyParentId: number;
+    patternName: string;
+    floorplanData: Prisma.InputJsonValue;
+    tag: string;
+    createdById: number;
+};
+
+export type FloorplanGenerationStatus = Pick<
+    CreateFloorPlanDataInput,
+    'jobId' | 'status' | 'progress'
+> & {
+    estimatedTime: string | null;
+};
+
+export type FloorPlanGenerationJobInfor = FloorplanGenerationStatus & {
+    requestPayload: RequestPayload;
+    // TODO: Redefine the resultPayload type after verifying the data structure in Python
+    resultPayload: any;
+    requestUserId: number;
+    historyParentId: number | null;
+};

--- a/backend/src/Types/FloorplanParam.ts
+++ b/backend/src/Types/FloorplanParam.ts
@@ -1,41 +1,44 @@
 import { Prisma } from '@prisma/client';
+import { JsonValue } from '@prisma/client/runtime/edge';
+
+export type LayoutConditions = {
+    family_composition: {
+        value: string;
+        unit: string;
+    };
+    number_of_floors: {
+        value: string;
+    };
+    frontage: {
+        value: string;
+        unit: string;
+    };
+    depth: {
+        value: string;
+        unit: string;
+    };
+    desired_LDK_area: {
+        value: string;
+        unit: string;
+    };
+    number_of_rooms: {
+        value: string;
+        unit: string;
+    };
+    number_of_toilets: {
+        value: string;
+        unit: string;
+    };
+    commitment_flow_lines: {
+        value: string;
+        unit: string;
+    };
+};
 
 export type RequestPayload = {
     title: string;
     clientName: string;
-    layout_conditions: {
-        family_composition: {
-            value: string;
-            unit: string;
-        };
-        number_of_floors: {
-            value: string;
-        };
-        frontage: {
-            value: string;
-            unit: string;
-        };
-        depth: {
-            value: string;
-            unit: string;
-        };
-        desired_LDK_area: {
-            value: string;
-            unit: string;
-        };
-        number_of_rooms: {
-            value: string;
-            unit: string;
-        };
-        number_of_toilets: {
-            value: string;
-            unit: string;
-        };
-        commitment_flow_lines: {
-            value: string;
-            unit: string;
-        };
-    };
+    layout_conditions: LayoutConditions;
 };
 
 export type CreateFloorPlanDataInput = {
@@ -76,4 +79,48 @@ export type FloorPlanGenerationJobInfor = FloorplanGenerationStatus & {
     resultPayload: any;
     requestUserId: number;
     historyParentId: number | null;
+};
+
+export type RegenerateHistoryParent = {
+    title: string | null;
+    customerName: string | null;
+    conditions: LayoutConditions;
+};
+
+export type FloorplanRoom = {
+    name: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+};
+
+export type FloorplanObject = FloorplanRoom & {
+    imageUrl: string;
+};
+
+export type FloorData = {
+    rooms: FloorplanRoom[];
+    objects: FloorplanObject[];
+};
+
+export type FloorplanData = {
+    first_floor_area: number;
+    second_floor_area: number;
+    total_floor_area: number;
+    tag: string[];
+    type: string;
+    '1': FloorData;
+    '2': FloorData;
+};
+
+export type HistoryChildFloorplanData = {
+    floorplanData: FloorplanData;
+};
+
+export type FloorplanImage = {
+    images: {
+        name: string;
+        url: string;
+    }[];
 };

--- a/backend/src/Types/LoginParam.ts
+++ b/backend/src/Types/LoginParam.ts
@@ -1,7 +1,7 @@
 import { Role } from '@prisma/client';
 
 export type UserByEmail = {
-    id: number;
+    id: number; // user id
     name: string | null;
     password: string | null;
     role: Role;
@@ -12,4 +12,6 @@ export type LoginResult = Pick<UserByEmail, 'id' | 'name'> & {
     token: string;
 };
 
-export type AuthTokenPayload = Pick<UserByEmail, 'role' | 'companyId'>;
+export type AuthTokenPayload = Pick<UserByEmail, 'role' | 'companyId'> & {
+    userId: number;
+};

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,7 +4,13 @@
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import DSMgr from './DSMgr';
-import { UserModificationError, LoginError, FloorplanGenerationError } from './ApplicationErrors';
+import {
+    UserModificationError,
+    LoginError,
+    FloorplanGenerationError,
+    FloorplanGenerationNotCompletedError,
+    FloorplanImageError
+} from './ApplicationErrors';
 import morgan from 'morgan';
 import cors from 'cors';
 import { body, param } from 'express-validator';
@@ -13,11 +19,19 @@ import { validatorErrorChecker } from './middlewares/validator.middleware';
 import { AuthTokenPayload } from './Types/LoginParam';
 import { env } from '../env';
 import { Role } from '@prisma/client';
+import multer from 'multer';
+import { AppConstant } from './SpecificCommons';
 
 const app = express();
 const router = express.Router();
 const PORT = env.WEB_SERVER_PORT;
 const dsMgr = new DSMgr();
+const upload = multer({
+    storage: multer.memoryStorage(),
+    limits: {
+        fileSize: AppConstant.FLOORPLAN.IMAGE.MAX_FILE_SIZE // 5MB
+    }
+});
 
 // cross-origin resource sharing
 app.use(
@@ -521,7 +535,13 @@ router.get(
             const result = await dsMgr.getFloorplanGenerationResults(req.params.jobId, authPayload);
             res.json(result);
         } catch (err) {
-            res.sendStatus(500);
+            if (err instanceof FloorplanGenerationError) {
+                res.sendStatus(404);
+            } else if (err instanceof FloorplanGenerationNotCompletedError) {
+                res.sendStatus(425);
+            } else {
+                res.sendStatus(500);
+            }
             return next(err);
         }
     }
@@ -576,6 +596,176 @@ router.delete(
             res.sendStatus(200);
         } catch (err) {
             res.sendStatus(500);
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Regenerate floorplan.
+ *      Request param:
+ *          curl -i -X POST -H "Authorization: TOKEN"
+ *          http://localhost:4000/api/v1/floorplans/regeneration/5
+ *
+ *      Response: jobId
+ *
+ */
+router.post(
+    '/floorplans/regeneration/:historyParentId',
+    [param('historyParentId').exists().isNumeric()],
+    refreshTokenIfValid,
+    authorizeRoles(Role.MEMBER),
+    validatorErrorChecker,
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const authPayload: AuthTokenPayload | undefined = req.user;
+            if (!authPayload) {
+                res.sendStatus(403);
+                return;
+            }
+            const historyParentId: number = Number(req.params.historyParentId);
+            const userId: number = authPayload.userId;
+            const jobId = await dsMgr.regenerateFloorplan(historyParentId, userId);
+            res.json(jobId);
+        } catch (err) {
+            if (err instanceof FloorplanGenerationError) {
+                res.sendStatus(404);
+            } else {
+                res.sendStatus(500);
+            }
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Updates a floorplan.
+ *      Request param:
+ *          curl -i -X PUT -H "Content-Type: application/json" -H "Authorization: TOKEN"
+ *          -d "{\"floorplanData\": {
+ *              \"first_floor_area\": 120.5,
+ *              \"second_floor_area\": 95.3,
+ *              \"total_floor_area\": 215.8,
+ *              \"tag\": [\"hogehoge\", \"naninani\", \"wowo\"],
+ *              \"type\": \"リビングが広いプラン\",
+ *              \"1\": {
+ *                  \"rooms\": [
+ *                      {\"name\": \"エントランス\", \"x\": 6.0, \"y\": 0.0, \"width\": 2.0, \"height\": 2.0}
+ *                  ],
+ *                  \"objects\": [
+ *                      {\"name\": \"シンク\", \"x\": 3.5, \"y\": 4.5, \"width\": 1.0, \"height\": 2.0, \"imageUrl\": \"https://test/images/sample.jpg\"}
+ *                  ]
+ *              },
+ *              \"2\": {
+ *                  \"rooms\": [
+ *                      {\"name\": \"廊下\", \"x\": 1.0, \"y\": 1.0, \"width\": 8.0, \"height\": 1.0}
+ *                  ],
+ *                  \"objects\": [
+ *                      {\"name\": \"ベッド\", \"x\": 8.5, \"y\": 2.5, \"width\": 2.5, \"height\": 1.5, \"imageUrl\": \"https://test/images/sample.jpg\"}
+ *                  ]
+ *              }
+ *          }}"
+ *          http://localhost:4000/api/v1/floorplans/update/5
+ *
+ */
+router.put(
+    '/floorplans/update/:historyChildId',
+    [param('historyChildId').exists().isNumeric(), body('floorplanData').notEmpty().isObject()],
+    refreshTokenIfValid,
+    authorizeRoles(Role.MEMBER),
+    validatorErrorChecker,
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const historyChildId = Number(req.params.historyChildId);
+            await dsMgr.updateFloorplan(historyChildId, req.body.floorplanData);
+            res.sendStatus(200);
+        } catch (err) {
+            res.sendStatus(500);
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Gets a list of equipment images.
+ *      Request param:
+ *          curl -i -X GET -H "Authorization: TOKEN"
+ *          http://localhost:4000/api/v1/floorplans/images
+ *
+ *      Response: List of equipment images
+ *
+ */
+router.get(
+    '/floorplans/images',
+    refreshTokenIfValid,
+    authorizeRoles(Role.MEMBER),
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const images = await dsMgr.getFloorplanImages();
+            res.json(images);
+        } catch (err) {
+            res.sendStatus(500);
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Uploads an equipment image.
+ *      Request param:
+ *          curl -i -X POST -H "Authorization: TOKEN" -F "image=@/path/to/椅子1_椅子.png"
+ *          http://localhost:4000/api/v1/floorplans/image
+ *
+ */
+router.post(
+    '/floorplans/image',
+    refreshTokenIfValid,
+    authorizeRoles(Role.MEMBER),
+    upload.single('image'),
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            if (!req.file) {
+                res.status(400).json({ error: 'No image file provided' });
+                return;
+            }
+
+            await dsMgr.uploadFloorplanImage(req.file);
+            res.sendStatus(200);
+        } catch (err) {
+            if (err instanceof FloorplanImageError) {
+                res.sendStatus(400);
+            } else {
+                res.sendStatus(500);
+            }
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Deletes an equipment image.
+ *      Request param:
+ *          curl -i -X DELETE -H "Content-Type: application/json" -H "Authorization: TOKEN"
+ *          -d "{\"name\": \"テーブル3_テーブル.png\"}"
+ *          http://localhost:4000/api/v1/floorplans/image
+ *
+ */
+router.delete(
+    '/floorplans/image',
+    [body('name').trim().notEmpty().isString()],
+    refreshTokenIfValid,
+    authorizeRoles(Role.MEMBER),
+    validatorErrorChecker,
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            await dsMgr.deleteFloorplanImage(req.body.name);
+            res.sendStatus(200);
+        } catch (err) {
+            if (err instanceof FloorplanImageError) {
+                res.sendStatus(400);
+            } else {
+                res.sendStatus(500);
+            }
             return next(err);
         }
     }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,7 +4,7 @@
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import DSMgr from './DSMgr';
-import { UserModificationError, LoginError } from './ApplicationErrors';
+import { UserModificationError, LoginError, FloorplanGenerationError } from './ApplicationErrors';
 import morgan from 'morgan';
 import cors from 'cors';
 import { body, param } from 'express-validator';
@@ -355,6 +355,7 @@ router.get(
     '/histories/:userId',
     [param('userId').exists().isNumeric()],
     refreshTokenIfValid,
+    validatorErrorChecker,
     async (req: Request, res: Response, next: NextFunction) => {
         try {
             const authPayload: AuthTokenPayload | undefined = req.user;
@@ -384,6 +385,7 @@ router.get(
     [param('historyParentId').exists().isNumeric()],
     [param('userId').exists().isNumeric()],
     refreshTokenIfValid,
+    validatorErrorChecker,
     async (req: Request, res: Response, next: NextFunction) => {
         try {
             const authPayload: AuthTokenPayload | undefined = req.user;
@@ -395,6 +397,183 @@ router.get(
             const userId: number = Number(req.params.userId);
             const result = await dsMgr.getHistoryChildren(historyParentId, userId, authPayload);
             res.json(result);
+        } catch (err) {
+            res.sendStatus(500);
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Floorplan generation request.
+ *      Request param:
+ *          curl -i -X POST -H "Content-Type: application/json" -H "Authorization: TOKEN"
+ *          -d "{\"title\": \"佐藤様邸間取りプラン\", \"clientName\": \"佐藤太郎\",
+ *          \"layout_conditions\": {
+ *              \"family_composition\": {\"value\": \"4\", \"unit\": \"people\"},
+ *              \"number_of_floors\": {\"value\": \"2\"},
+ *              \"frontage\": {\"value\": \"20\", \"unit\": \"pit\"},
+ *              \"depth\": {\"value\": \"12\", \"unit\": \"pit\"},
+ *              \"desired_LDK_area\": {\"value\": \"18\", \"unit\": \"tatami\"},
+ *              \"number_of_rooms\": {\"value\": \"3\", \"unit\": \"rooms\"},
+ *              \"number_of_toilets\": {\"value\": \"2\", \"unit\": \"units\"},
+ *              \"commitment_flow_lines\": {\"value\": \"玄関からキッチンまで動線を短く\", \"unit\": \"text\"}
+ *          }}"
+ *          http://localhost:4000/api/v1/floorplans
+ *
+ *      Response: jobId
+ *
+ */
+router.post(
+    '/floorplans',
+    [
+        body('title').trim().notEmpty().isString(),
+        body('clientName').trim().notEmpty().isString(),
+        body('layout_conditions').notEmpty().isObject(),
+        body('layout_conditions.family_composition.value').trim().notEmpty().isString(),
+        body('layout_conditions.family_composition.unit').trim().notEmpty().isString(),
+        body('layout_conditions.number_of_floors.value').trim().notEmpty().isString(),
+        body('layout_conditions.frontage.value').trim().notEmpty().isString(),
+        body('layout_conditions.frontage.unit').trim().notEmpty().isString(),
+        body('layout_conditions.depth.value').trim().notEmpty().isString(),
+        body('layout_conditions.depth.unit').trim().notEmpty().isString(),
+        body('layout_conditions.desired_LDK_area.value').trim().notEmpty().isString(),
+        body('layout_conditions.desired_LDK_area.unit').trim().notEmpty().isString(),
+        body('layout_conditions.number_of_rooms.value').trim().notEmpty().isString(),
+        body('layout_conditions.number_of_rooms.unit').trim().notEmpty().isString(),
+        body('layout_conditions.number_of_toilets.value').trim().notEmpty().isString(),
+        body('layout_conditions.number_of_toilets.unit').trim().notEmpty().isString(),
+        body('layout_conditions.commitment_flow_lines.value').trim().notEmpty().isString(),
+        body('layout_conditions.commitment_flow_lines.unit').trim().notEmpty().isString()
+    ],
+    refreshTokenIfValid,
+    authorizeRoles(Role.MEMBER),
+    validatorErrorChecker,
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const authPayload: AuthTokenPayload | undefined = req.user;
+            if (!authPayload) {
+                res.sendStatus(403);
+                return;
+            }
+            const userId: number = authPayload.userId;
+            const jobId = await dsMgr.createFloorplanGenerationJob(req.body, userId);
+            res.json(jobId);
+        } catch (err) {
+            res.sendStatus(500);
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Get floorplan generation status.
+ *      Request param:
+ *          curl -i -X GET -H "Authorization: TOKEN"
+ *          http://localhost:4000/api/v1/floorplans/status/550e8400-e29b-41d4-a716-446655440000
+ *
+ *      Response: Floorplan generation status information
+ *
+ */
+router.get(
+    '/floorplans/status/:jobId/',
+    [param('jobId').trim().notEmpty().isString().isLength({ min: 36, max: 36 })],
+    refreshTokenIfValid,
+    authorizeRoles(Role.MEMBER),
+    validatorErrorChecker,
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const result = await dsMgr.getFloorplanGenerationStatus(req.params.jobId);
+            res.json(result);
+        } catch (err) {
+            if (err instanceof FloorplanGenerationError) {
+                res.sendStatus(404);
+            } else {
+                res.sendStatus(500);
+            }
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Get floorplan generation results.
+ *      Request param:
+ *          curl -i -X GET -H "Authorization: TOKEN"
+ *          http://localhost:4000/api/v1/floorplans/results/550e8400-e29b-41d4-a716-446655440000
+ *
+ *      Response: Floorplan generation results
+ *
+ */
+router.get(
+    '/floorplans/results/:jobId/',
+    [param('jobId').trim().notEmpty().isString().isLength({ min: 36, max: 36 })],
+    refreshTokenIfValid,
+    authorizeRoles(Role.MEMBER),
+    validatorErrorChecker,
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const authPayload: AuthTokenPayload | undefined = req.user;
+            if (!authPayload) {
+                res.sendStatus(403);
+                return;
+            }
+            const result = await dsMgr.getFloorplanGenerationResults(req.params.jobId, authPayload);
+            res.json(result);
+        } catch (err) {
+            res.sendStatus(500);
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Toggles the favorite status of a floorplan.
+ *      Request param:
+ *          curl -i -X PUT -H "Content-Type: application/json" -H "Authorization: TOKEN"
+ *          -d "{\"isPatternFavorite\": true}"
+ *          http://localhost:4000/api/v1/floorplans/plans/5/favorite
+ *
+ */
+router.put(
+    '/floorplans/plans/:historyChildId/favorite',
+    [
+        param('historyChildId').exists().isNumeric(),
+        body('isPatternFavorite').notEmpty().isBoolean()
+    ],
+    refreshTokenIfValid,
+    authorizeRoles(Role.MEMBER),
+    validatorErrorChecker,
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const historyChildId = Number(req.params.historyChildId);
+            await dsMgr.toggleHistoryChildFavorite(historyChildId, req.body.isPatternFavorite);
+            res.sendStatus(200);
+        } catch (err) {
+            res.sendStatus(500);
+            return next(err);
+        }
+    }
+);
+
+/**
+ *  Deletes a floorplan.
+ *      Request param:
+ *          curl -i -X DELETE -H "Authorization: TOKEN"
+ *          http://localhost:4000/api/v1/floorplans/plans/5
+ *
+ */
+router.delete(
+    '/floorplans/plans/:historyChildId',
+    [param('historyChildId').exists().isNumeric()],
+    refreshTokenIfValid,
+    authorizeRoles(Role.SYSTEM_ADMIN),
+    validatorErrorChecker,
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const historyChildId = Number(req.params.historyChildId);
+            await dsMgr.removeHistoryChild(historyChildId);
+            res.sendStatus(200);
         } catch (err) {
             res.sendStatus(500);
             return next(err);


### PR DESCRIPTION
1. 間取り生成リクエスト
2. 間取り生成ステータス確認
3. 間取り生成結果取得
4. プランお気に入り登録/解除
5. プラン削除

5個のAPIを実装しまｓた。
`FloorPlanGenerationJob`テーブルに`requestUserId`カラムを追加しない場合、エラーが発生します。